### PR TITLE
feat: granular notification fields, battery app-impact insights, and real-time counter updates

### DIFF
--- a/app/src/main/java/com/extensionbox/app/MonitorService.kt
+++ b/app/src/main/java/com/extensionbox/app/MonitorService.kt
@@ -8,16 +8,15 @@ import android.app.Service
 import android.content.Intent
 import android.os.IBinder
 import android.os.SystemClock
-import android.text.TextUtils
 import androidx.core.app.NotificationCompat
-import com.extensionbox.app.modules.*
-import com.extensionbox.app.widgets.ModuleWidgetProvider
-import kotlinx.coroutines.*
 import com.extensionbox.app.db.AppDatabase
 import com.extensionbox.app.db.ModuleDataEntity
+import com.extensionbox.app.modules.*
+import com.extensionbox.app.widgets.ModuleWidgetProvider
 import java.util.Calendar
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.abs
+import kotlinx.coroutines.*
 
 class MonitorService : Service() {
 
@@ -52,25 +51,29 @@ class MonitorService : Service() {
     private var syncJob: Job? = null
     private val moduleStates = ConcurrentHashMap<String, Boolean>()
 
-    private val powerReceiver = object : android.content.BroadcastReceiver() {
-        override fun onReceive(context: android.content.Context?, intent: android.content.Intent?) {
-            when (intent?.action) {
-                Intent.ACTION_SCREEN_ON -> {
-                    isScreenOn = true
-                    lastNotifUpdateTime = 0L // Force update on screen on
-                    if (initialized) startTicker() // Immediate refresh on wake
-                }
-                Intent.ACTION_SCREEN_OFF -> {
-                    isScreenOn = false
-                }
-                Intent.ACTION_POWER_CONNECTED -> {
-                    if (Prefs.getBool(this@MonitorService, "scr_reset_plugged", false)) {
-                        resetAllModules()
+    private val powerReceiver =
+            object : android.content.BroadcastReceiver() {
+                override fun onReceive(
+                        context: android.content.Context?,
+                        intent: android.content.Intent?
+                ) {
+                    when (intent?.action) {
+                        Intent.ACTION_SCREEN_ON -> {
+                            isScreenOn = true
+                            lastNotifUpdateTime = 0L // Force update on screen on
+                            if (initialized) startTicker() // Immediate refresh on wake
+                        }
+                        Intent.ACTION_SCREEN_OFF -> {
+                            isScreenOn = false
+                        }
+                        Intent.ACTION_POWER_CONNECTED -> {
+                            if (Prefs.getBool(this@MonitorService, "scr_reset_plugged", false)) {
+                                resetAllModules()
+                            }
+                        }
                     }
                 }
             }
-        }
-    }
 
     fun getFapModule(): FapCounterModule? {
         return if (initialized) modules.filterIsInstance<FapCounterModule>().firstOrNull() else null
@@ -83,77 +86,82 @@ class MonitorService : Service() {
 
         // Start foreground immediately to satisfy system requirements
         startForeground(NOTIF_ID, buildNotification())
-        
-        val filter = android.content.IntentFilter().apply {
-            addAction(Intent.ACTION_SCREEN_ON)
-            addAction(Intent.ACTION_SCREEN_OFF)
-            addAction(Intent.ACTION_POWER_CONNECTED)
-        }
+
+        val filter =
+                android.content.IntentFilter().apply {
+                    addAction(Intent.ACTION_SCREEN_ON)
+                    addAction(Intent.ACTION_SCREEN_OFF)
+                    addAction(Intent.ACTION_POWER_CONNECTED)
+                }
         registerReceiver(powerReceiver, filter)
 
         // Asynchronous heavy initialization
         serviceScope.launch(Dispatchers.IO) {
             database = AppDatabase.getDatabase(this@MonitorService)
             sysAccess = SystemAccess(this@MonitorService)
-            
-            modules = listOf(
-                BatteryModule(),
-                AppUsageModule(),
-                CpuModule(),
-                RamModule(),
-                SleepModule(),
-                NetworkModule(),
-                DataUsageModule(),
-                UnlockModule(),
-                StorageModule(),
-                ConnectionModule(),
-                UptimeModule(),
-                StepModule(),
-                SpeedTestModule(),
-                FapCounterModule()
-            )
-            
+
+            modules =
+                    listOf(
+                            BatteryModule(),
+                            AppUsageModule(),
+                            CpuModule(),
+                            RamModule(),
+                            SleepModule(),
+                            NetworkModule(),
+                            DataUsageModule(),
+                            UnlockModule(),
+                            StorageModule(),
+                            ConnectionModule(),
+                            UptimeModule(),
+                            StepModule(),
+                            SpeedTestModule(),
+                            FapCounterModule()
+                    )
+
             initialized = true
             startPreferenceObservation()
             startTicker()
         }
-        
+
         Prefs.setRunning(this, true)
     }
 
     private fun startPreferenceObservation() {
         syncJob?.cancel()
-        syncJob = serviceScope.launch(Dispatchers.IO) {
-            this@MonitorService.dataStore.data.collect { prefs ->
-                for (m in modules) {
-                    val key = "m_${m.key()}_enabled"
-                    val prefKey = androidx.datastore.preferences.core.booleanPreferencesKey(key)
-                    val isEnabled = prefs[prefKey] ?: m.defaultEnabled()
-                    moduleStates[m.key()] = isEnabled
-                    
-                    if (isEnabled && !m.alive()) {
-                        m.start(this@MonitorService, sysAccess)
-                        lastTickTime[m.key()] = 0L
-                    } else if (!isEnabled && m.alive()) {
-                        m.stop()
-                        moduleData.remove(m.key())
-                        lastTickTime.remove(m.key())
+        syncJob =
+                serviceScope.launch(Dispatchers.IO) {
+                    this@MonitorService.dataStore.data.collect { prefs ->
+                        for (m in modules) {
+                            val key = "m_${m.key()}_enabled"
+                            val prefKey =
+                                    androidx.datastore.preferences.core.booleanPreferencesKey(key)
+                            val isEnabled = prefs[prefKey] ?: m.defaultEnabled()
+                            moduleStates[m.key()] = isEnabled
+
+                            if (isEnabled && !m.alive()) {
+                                m.start(this@MonitorService, sysAccess)
+                                lastTickTime[m.key()] = 0L
+                            } else if (!isEnabled && m.alive()) {
+                                m.stop()
+                                moduleData.remove(m.key())
+                                lastTickTime.remove(m.key())
+                            }
+                        }
                     }
                 }
-            }
-        }
     }
 
     private fun startTicker() {
         if (!initialized) return
         tickerJob?.cancel()
-        tickerJob = serviceScope.launch(Dispatchers.IO) {
-            while (isActive) {
-                doTickCycle()
-                val delayMs = calculateNextDelay()
-                delay(delayMs)
-            }
-        }
+        tickerJob =
+                serviceScope.launch(Dispatchers.IO) {
+                    while (isActive) {
+                        doTickCycle()
+                        val delayMs = calculateNextDelay()
+                        delay(delayMs)
+                    }
+                }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -178,7 +186,7 @@ class MonitorService : Service() {
 
     private fun checkBatteryFullReset() {
         if (!initialized || !Prefs.getBool(this, "scr_reset_full", true)) return
-        
+
         val batMod = modules.filterIsInstance<BatteryModule>().firstOrNull() ?: return
         if (!batMod.alive()) return
 
@@ -208,17 +216,13 @@ class MonitorService : Service() {
         try {
             unregisterReceiver(powerReceiver)
         } catch (ignored: Exception) {}
-        
+
         if (::sysAccess.isInitialized) {
             sysAccess.onDestroy()
         }
-        
-        runBlocking {
-            withContext(Dispatchers.IO) {
-                if (initialized) stopAll()
-            }
-        }
-        
+
+        runBlocking { withContext(Dispatchers.IO) { if (initialized) stopAll() } }
+
         Prefs.setRunning(this, false)
         moduleData.clear()
         instance = null
@@ -227,59 +231,59 @@ class MonitorService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? = null
 
-    private suspend fun doTickCycle() = withContext(Dispatchers.IO) {
-        if (!initialized) return@withContext
-        checkRollover()
-        checkBatteryFullReset()
-        val now = SystemClock.elapsedRealtime()
-        var changed = false
-        val entitiesToInsert = mutableListOf<ModuleDataEntity>()
+    private suspend fun doTickCycle() =
+            withContext(Dispatchers.IO) {
+                if (!initialized) return@withContext
+                checkRollover()
+                checkBatteryFullReset()
+                val now = SystemClock.elapsedRealtime()
+                var changed = false
+                val entitiesToInsert = mutableListOf<ModuleDataEntity>()
 
-        for (m in modules) {
-            val isEnabled = moduleStates[m.key()] ?: m.defaultEnabled()
-            if (!isEnabled || !m.alive()) continue
-            
-            val last = lastTickTime[m.key()] ?: 0L
-            val interval = if (isScreenOn) m.tickIntervalMs() else m.tickIntervalMs() * 3
-            if (now - last >= interval) {
-                try {
-                    m.tick()
-                    m.checkAlerts(this@MonitorService)
-                    lastTickTime[m.key()] = now
-                    val dp = m.dataPoints()
-                    moduleData[m.key()] = dp
-                    
-                    // Collect for batch insert
-                    entitiesToInsert.add(ModuleDataEntity(moduleKey = m.key(), data = dp))
-                    
-                    changed = true
-                } catch (e: Exception) {
-                    e.printStackTrace()
+                for (m in modules) {
+                    val isEnabled = moduleStates[m.key()] ?: m.defaultEnabled()
+                    if (!isEnabled || !m.alive()) continue
+
+                    val last = lastTickTime[m.key()] ?: 0L
+                    val interval = if (isScreenOn) m.tickIntervalMs() else m.tickIntervalMs() * 3
+                    if (now - last >= interval) {
+                        try {
+                            m.tick()
+                            m.checkAlerts(this@MonitorService)
+                            lastTickTime[m.key()] = now
+                            val dp = m.dataPoints()
+                            moduleData[m.key()] = dp
+
+                            // Collect for batch insert
+                            entitiesToInsert.add(ModuleDataEntity(moduleKey = m.key(), data = dp))
+
+                            changed = true
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                        }
+                    }
                 }
-            }
-        }
 
-        if (entitiesToInsert.isNotEmpty()) {
-            database.moduleDataDao().insertAll(entitiesToInsert)
-        }
-        
-        val notifInterval = Prefs.getLong(this@MonitorService, "notif_refresh_ms", 10000L)
-        if (changed && (now - lastNotifUpdateTime >= notifInterval)) {
-            lastNotifUpdateTime = now
-            withContext(Dispatchers.Main) {
-                updateNotification()
+                if (entitiesToInsert.isNotEmpty()) {
+                    database.moduleDataDao().insertAll(entitiesToInsert)
+                }
+
+                val notifInterval = Prefs.getLong(this@MonitorService, "notif_refresh_ms", 10000L)
+                if (changed && (now - lastNotifUpdateTime >= notifInterval)) {
+                    lastNotifUpdateTime = now
+                    withContext(Dispatchers.Main) { updateNotification() }
+                    // Throttled widget update (e.g. at least 30s)
+                    val lastWidgetUpdate =
+                            Prefs.getLong(this@MonitorService, "last_widget_update_time", 0L)
+                    if (now - lastWidgetUpdate >= 30000L) {
+                        Prefs.setLong(this@MonitorService, "last_widget_update_time", now)
+                        try {
+                            ModuleWidgetProvider.updateAllWidgets(this@MonitorService)
+                        } catch (ignored: Exception) {}
+                    }
+                }
+                checkNightSummary()
             }
-            // Throttled widget update (e.g. at least 30s)
-            val lastWidgetUpdate = Prefs.getLong(this@MonitorService, "last_widget_update_time", 0L)
-            if (now - lastWidgetUpdate >= 30000L) {
-                Prefs.setLong(this@MonitorService, "last_widget_update_time", now)
-                try {
-                    ModuleWidgetProvider.updateAllWidgets(this@MonitorService)
-                } catch (ignored: Exception) {}
-            }
-        }
-        checkNightSummary()
-    }
 
     private fun checkRollover() {
         if (!initialized) return
@@ -374,51 +378,76 @@ class MonitorService : Service() {
 
     private fun createChannels() {
         val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-        val monCh = NotificationChannel(MONITOR_CH, "Extension Box Monitor", NotificationManager.IMPORTANCE_LOW).apply {
-            setShowBadge(false)
-            enableVibration(false)
-            setSound(null, null)
-        }
+        val monCh =
+                NotificationChannel(
+                                MONITOR_CH,
+                                "Extension Box Monitor",
+                                NotificationManager.IMPORTANCE_LOW
+                        )
+                        .apply {
+                            setShowBadge(false)
+                            enableVibration(false)
+                            setSound(null, null)
+                        }
         nm.createNotificationChannel(monCh)
-        val alertCh = NotificationChannel(ALERT_CH, "Extension Box Alerts", NotificationManager.IMPORTANCE_HIGH)
+        val alertCh =
+                NotificationChannel(
+                        ALERT_CH,
+                        "Extension Box Alerts",
+                        NotificationManager.IMPORTANCE_HIGH
+                )
         nm.createNotificationChannel(alertCh)
     }
 
     private fun buildNotification(): Notification {
         val openIntent = Intent(this, MainActivity::class.java)
-        val openPi = PendingIntent.getActivity(this, 0, openIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-        
+        val openPi =
+                PendingIntent.getActivity(
+                        this,
+                        0,
+                        openIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+
         val stopIntent = Intent(this, MonitorService::class.java).setAction(ACTION_STOP)
-        val stopPi = PendingIntent.getService(this, 1, stopIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+        val stopPi =
+                PendingIntent.getService(
+                        this,
+                        1,
+                        stopIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
 
         val isDismissible = Prefs.getBool(this, "notif_dismissible", false)
         val bigText = NotificationCompat.BigTextStyle().bigText(buildExpanded())
 
         return NotificationCompat.Builder(this, MONITOR_CH)
-            .setSmallIcon(R.drawable.ic_notif)
-            .setContentTitle(buildTitle())
-            .setContentText(buildCompact())
-            .setStyle(bigText)
-            .setOngoing(!isDismissible)
-            .setDeleteIntent(if (isDismissible) stopPi else null)
-            .setOnlyAlertOnce(true)
-            .setPriority(NotificationCompat.PRIORITY_LOW)
-            .setCategory(NotificationCompat.CATEGORY_STATUS)
-            .setContentIntent(openPi)
-            .addAction(0, "■ Stop", stopPi)
-            .setShowWhen(false)
-            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
-            .build()
+                .setSmallIcon(R.drawable.ic_notif)
+                .setContentTitle(buildTitle())
+                .setContentText(buildCompact())
+                .setStyle(bigText)
+                .setOngoing(!isDismissible)
+                .setDeleteIntent(if (isDismissible) stopPi else null)
+                .setOnlyAlertOnce(true)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setContentIntent(openPi)
+                .addAction(0, "■ Stop", stopPi)
+                .setShowWhen(false)
+                .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
+                .build()
     }
 
     private fun buildTitle(): String {
         if (!::modules.isInitialized) return "Extension Box"
         val contextAware = Prefs.getBool(this, "notif_context_aware", true)
-        val batMod = modules.filterIsInstance<BatteryModule>().firstOrNull() ?: return "Extension Box"
+        val batMod =
+                modules.filterIsInstance<BatteryModule>().firstOrNull() ?: return "Extension Box"
         if (!batMod.alive()) return "Extension Box"
 
         val lvl = batMod.getLevel()
-        return if (contextAware && lvl <= 15) "⚠ Extension Box • $lvl% Low!" else "Extension Box • $lvl%"
+        return if (contextAware && lvl <= 15) "⚠ Extension Box • $lvl% Low!"
+        else "Extension Box • $lvl%"
     }
 
     private fun buildCompact(): String {
@@ -448,8 +477,11 @@ class MonitorService : Service() {
     private fun buildExpanded(): String {
         if (!::modules.isInitialized) return "Starting..."
         val layoutStyle = Prefs.getString(this, "notif_layout_style", "LIST") ?: "LIST"
-        val alive = getAliveModulesSorted()
-        
+        val alive =
+                getAliveModulesSorted()
+                        .map { module -> module to getVisibleNotificationDataPoints(module) }
+                        .filter { it.second.isNotEmpty() }
+
         if (alive.isEmpty()) return "Enable extensions from the app"
 
         return when (layoutStyle) {
@@ -459,26 +491,81 @@ class MonitorService : Service() {
                     val m1 = alive[i]
                     val m2 = if (i + 1 < alive.size) alive[i + 1] else null
                     if (m2 != null) {
-                        lines.add("• ${m1.name().take(8)}: ${m1.compact()} | ${m2.name().take(8)}: ${m2.compact()}")
+                        val left = renderDataPointsInline(m1.second, 1)
+                        val right = renderDataPointsInline(m2.second, 1)
+                        lines.add("• ${m1.first.name().take(8)}: $left")
+                        lines.add("• ${m2.first.name().take(8)}: $right")
                     } else {
-                        lines.add("• ${m1.name()}: ${m1.compact()}")
+                        lines.add("• ${m1.first.name()}: ${renderDataPointsInline(m1.second, 2)}")
                     }
                 }
                 lines.joinToString("\n")
             }
             "COMPACT" -> {
-                alive.joinToString("  •  ") { m -> m.compact() }
+                alive.joinToString("  •  ") { moduleAndPoints ->
+                    "${moduleAndPoints.first.name()}: ${renderDataPointsInline(moduleAndPoints.second, 1)}"
+                }
             }
             else -> { // LIST
-                val compactStyle = Prefs.getBool(this, "notif_compact_style", true)
-                val lines = if (compactStyle) {
-                    alive.map { m -> "• ${m.name()}: ${m.compact()}" }
-                } else {
-                    alive.map { m -> m.detail() }
-                }
+                val lines =
+                        alive.flatMap { moduleAndPoints ->
+                            buildAdaptiveModuleLines(
+                                    moduleAndPoints.first.name(),
+                                    moduleAndPoints.second
+                            )
+                        }
                 lines.joinToString("\n")
             }
         }
+    }
+
+    private fun getVisibleNotificationDataPoints(module: Module): List<Pair<String, String>> {
+        val points = moduleData[module.key()] ?: module.dataPoints()
+        if (points.isEmpty()) return emptyList()
+        return points.entries.mapNotNull { entry ->
+            val rawKey = entry.key.substringAfterLast('.')
+            val visible = Prefs.isModuleDataPointVisibleInNotif(this, module.key(), rawKey)
+            if (!visible) {
+                null
+            } else {
+                val label = rawKey.replace("_", " ").replaceFirstChar { it.uppercase() }
+                label to entry.value
+            }
+        }
+    }
+
+    private fun renderDataPointsInline(
+            points: List<Pair<String, String>>,
+            maxItems: Int = Int.MAX_VALUE
+    ): String {
+        return points.take(maxItems).joinToString(" • ") { pair -> "${pair.first}: ${pair.second}" }
+    }
+
+    private fun buildAdaptiveModuleLines(
+            moduleName: String,
+            points: List<Pair<String, String>>
+    ): List<String> {
+        val lines = mutableListOf<String>()
+        lines.add("• $moduleName")
+        var index = 0
+        val pairThreshold = 46
+
+        while (index < points.size) {
+            val current = "${points[index].first}: ${points[index].second}"
+            if (index + 1 < points.size) {
+                val next = "${points[index + 1].first}: ${points[index + 1].second}"
+                val candidate = "$current  •  $next"
+                if (candidate.length <= pairThreshold) {
+                    lines.add("  $candidate")
+                    index += 2
+                    continue
+                }
+            }
+            lines.add("  $current")
+            index += 1
+        }
+
+        return lines
     }
 
     private fun getAliveModulesSorted(): List<Module> {
@@ -545,24 +632,23 @@ class MonitorService : Service() {
 
         try {
             val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-            val n = NotificationCompat.Builder(this, ALERT_CH)
-                .setSmallIcon(R.drawable.ic_notif)
-                .setContentTitle("🌙 Daily Summary")
-                .setContentText(bodyStr)
-                .setStyle(NotificationCompat.BigTextStyle().bigText(bodyStr))
-                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-                .setAutoCancel(true)
-                .build()
+            val n =
+                    NotificationCompat.Builder(this, ALERT_CH)
+                            .setSmallIcon(R.drawable.ic_notif)
+                            .setContentTitle("🌙 Daily Summary")
+                            .setContentText(bodyStr)
+                            .setStyle(NotificationCompat.BigTextStyle().bigText(bodyStr))
+                            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                            .setAutoCancel(true)
+                            .build()
             nm.notify(NIGHT_SUMMARY_ID, n)
-        } catch (ignored: Exception) {
-        }
+        } catch (ignored: Exception) {}
     }
 
     private fun updateNotification() {
         try {
             val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
             nm.notify(NOTIF_ID, buildNotification())
-        } catch (ignored: Exception) {
-        }
+        } catch (ignored: Exception) {}
     }
 }

--- a/app/src/main/java/com/extensionbox/app/MonitorService.kt
+++ b/app/src/main/java/com/extensionbox/app/MonitorService.kt
@@ -178,10 +178,30 @@ class MonitorService : Service() {
                 }
             }
             ACTION_FAP_INCREMENT -> {
-                getFapModule()?.increment()
+                serviceScope.launch(Dispatchers.IO) {
+                    while (!initialized) delay(50)
+                    val module = getFapModule() ?: return@launch
+                    module.increment()
+                    publishModuleSnapshot(module, forceNotification = true)
+                }
             }
         }
         return START_STICKY
+    }
+
+    private suspend fun publishModuleSnapshot(module: Module, forceNotification: Boolean = false) {
+        if (!initialized || !module.alive()) return
+        val dp = module.dataPoints()
+        moduleData[module.key()] = dp
+        database.moduleDataDao().insert(ModuleDataEntity(moduleKey = module.key(), data = dp))
+        lastTickTime[module.key()] = SystemClock.elapsedRealtime()
+        if (forceNotification) {
+            lastNotifUpdateTime = 0L
+        }
+        withContext(Dispatchers.Main) { updateNotification() }
+        try {
+            ModuleWidgetProvider.updateAllWidgets(this@MonitorService)
+        } catch (ignored: Exception) {}
     }
 
     private fun checkBatteryFullReset() {

--- a/app/src/main/java/com/extensionbox/app/Prefs.kt
+++ b/app/src/main/java/com/extensionbox/app/Prefs.kt
@@ -19,6 +19,10 @@ val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
 
 object Prefs {
 
+    private fun sanitizeDataPointKey(value: String): String {
+        return value.lowercase().replace(Regex("[^a-z0-9]+"), "_").trim('_')
+    }
+
     // --- Synchronous Getters (Legacy bridge, uses runBlocking) ---
     // Note: In 2026 practice, we should migrate callers to observe flows or use suspended functions.
     // This bridge allows the app to function while we refactor.
@@ -108,6 +112,18 @@ object Prefs {
 
     fun setModuleVisibleInNotif(c: Context, key: String, value: Boolean) = runBlocking {
         val prefKey = booleanPreferencesKey("notif_m_${key}_visible")
+        c.dataStore.edit { it[prefKey] = value }
+    }
+
+    fun isModuleDataPointVisibleInNotif(c: Context, moduleKey: String, dataPointKey: String): Boolean = runBlocking {
+        val safeKey = sanitizeDataPointKey(dataPointKey)
+        val prefKey = booleanPreferencesKey("notif_dp_${moduleKey}_${safeKey}_visible")
+        c.dataStore.data.map { it[prefKey] ?: true }.first()
+    }
+
+    fun setModuleDataPointVisibleInNotif(c: Context, moduleKey: String, dataPointKey: String, value: Boolean) = runBlocking {
+        val safeKey = sanitizeDataPointKey(dataPointKey)
+        val prefKey = booleanPreferencesKey("notif_dp_${moduleKey}_${safeKey}_visible")
         c.dataStore.edit { it[prefKey] = value }
     }
 

--- a/app/src/main/java/com/extensionbox/app/ui/screens/ModuleDetailScreen.kt
+++ b/app/src/main/java/com/extensionbox/app/ui/screens/ModuleDetailScreen.kt
@@ -135,6 +135,11 @@ fun ModuleDetailScreen(
                     if (hasSettings) {
                         module.settingsContent(context, sysAccess)
                     }
+
+                    ModuleNotificationDataPointSettings(
+                        moduleKey = moduleKey,
+                        dataKeys = (data.keys + module.dataPoints().keys).toList()
+                    )
                     
                     if (isFap) {
                         Button(
@@ -156,5 +161,56 @@ fun ModuleDetailScreen(
         }
         
         Spacer(modifier = Modifier.height(100.dp))
+    }
+}
+
+@Composable
+private fun ModuleNotificationDataPointSettings(
+    moduleKey: String,
+    dataKeys: List<String>
+) {
+    val context = LocalContext.current
+    val normalizedKeys = remember(dataKeys) {
+        dataKeys
+            .map { it.substringAfterLast('.') }
+            .distinct()
+            .sorted()
+    }
+
+    if (normalizedKeys.isEmpty()) return
+
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+            text = "Notification Fields",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        normalizedKeys.forEach { rawKey ->
+            var isVisible by remember(moduleKey, rawKey) {
+                mutableStateOf(Prefs.isModuleDataPointVisibleInNotif(context, moduleKey, rawKey))
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = rawKey.replace("_", " ").replaceFirstChar { it.uppercase() },
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+
+                Switch(
+                    checked = isVisible,
+                    onCheckedChange = { enabled ->
+                        isVisible = enabled
+                        Prefs.setModuleDataPointVisibleInNotif(context, moduleKey, rawKey, enabled)
+                    }
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/extensionbox/app/ui/screens/ModuleDetailScreen.kt
+++ b/app/src/main/java/com/extensionbox/app/ui/screens/ModuleDetailScreen.kt
@@ -33,8 +33,24 @@ fun ModuleDetailScreen(moduleKey: String, viewModel: DashboardViewModel) {
     val dashData = viewModel.dashData.collectAsState().value
     val historyData = viewModel.historyData.collectAsState().value
     val sysAccess = viewModel.sysAccess.collectAsState().value
+    var fapLocalUpdateTick by remember { mutableStateOf(0) }
 
-    val data = dashData[moduleKey] ?: emptyMap()
+    val baseData = dashData[moduleKey] ?: emptyMap()
+    val data =
+            remember(moduleKey, baseData, fapLocalUpdateTick) {
+                if (moduleKey != "fap") {
+                    baseData
+                } else {
+                    baseData.toMutableMap().apply {
+                        put("fap.today", Prefs.getInt(context, "fap_today", 0).toString())
+                        put("fap.yesterday", Prefs.getInt(context, "fap_yesterday", 0).toString())
+                        val streak = Prefs.getInt(context, "fap_streak", 0)
+                        put("fap.streak", if (streak > 0) "${streak}d" else "0")
+                        put("fap.monthly", Prefs.getInt(context, "fap_monthly", 0).toString())
+                        put("fap.all_time", Prefs.getInt(context, "fap_all_time", 0).toString())
+                    }
+                }
+            }
     val history = historyData[moduleKey] ?: emptyList()
     val appUsageData = dashData["app_usage"] ?: emptyMap()
     val module = com.extensionbox.app.ui.ModuleRegistry.getModule(moduleKey)
@@ -175,6 +191,7 @@ fun ModuleDetailScreen(moduleKey: String, viewModel: DashboardViewModel) {
                                             Intent(context, MonitorService::class.java)
                                                     .setAction("com.extensionbox.app.FAP_INCREMENT")
                                     context.startService(intent)
+                                    fapLocalUpdateTick += 1
                                 },
                                 modifier = Modifier.fillMaxWidth(),
                                 shape = MaterialTheme.shapes.medium

--- a/app/src/main/java/com/extensionbox/app/ui/screens/ModuleDetailScreen.kt
+++ b/app/src/main/java/com/extensionbox/app/ui/screens/ModuleDetailScreen.kt
@@ -21,15 +21,14 @@ import androidx.compose.ui.unit.dp
 import com.extensionbox.app.MonitorService
 import com.extensionbox.app.Prefs
 import com.extensionbox.app.R
+import com.extensionbox.app.db.ModuleDataEntity
 import com.extensionbox.app.ui.ModuleRegistry
 import com.extensionbox.app.ui.components.*
 import com.extensionbox.app.ui.viewmodel.DashboardViewModel
+import kotlin.math.max
 
 @Composable
-fun ModuleDetailScreen(
-    moduleKey: String,
-    viewModel: DashboardViewModel
-) {
+fun ModuleDetailScreen(moduleKey: String, viewModel: DashboardViewModel) {
     val context = LocalContext.current
     val dashData = viewModel.dashData.collectAsState().value
     val historyData = viewModel.historyData.collectAsState().value
@@ -37,68 +36,88 @@ fun ModuleDetailScreen(
 
     val data = dashData[moduleKey] ?: emptyMap()
     val history = historyData[moduleKey] ?: emptyList()
+    val appUsageData = dashData["app_usage"] ?: emptyMap()
     val module = com.extensionbox.app.ui.ModuleRegistry.getModule(moduleKey)
     val scrollState = rememberScrollState()
 
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .verticalScroll(scrollState)
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+            modifier =
+                    Modifier.fillMaxSize()
+                            .background(MaterialTheme.colorScheme.background)
+                            .verticalScroll(scrollState)
+                            .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         if (history.isNotEmpty()) {
             Surface(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(220.dp),
-                shape = RoundedCornerShape(28.dp),
-                color = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)
+                    modifier = Modifier.fillMaxWidth().height(220.dp),
+                    shape = RoundedCornerShape(28.dp),
+                    color = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)
             ) {
                 Column(modifier = Modifier.padding(20.dp)) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Default.Timeline, null, modifier = Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+                        Icon(
+                                Icons.Default.Timeline,
+                                null,
+                                modifier = Modifier.size(16.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                        )
                         Spacer(Modifier.width(8.dp))
-                        Text(stringResource(id = R.string.history_15m), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
+                        Text(
+                                stringResource(id = R.string.history_15m),
+                                style = MaterialTheme.typography.labelLarge,
+                                fontWeight = FontWeight.Bold
+                        )
                     }
                     Spacer(Modifier.height(16.dp))
                     Box(modifier = Modifier.fillMaxSize()) {
                         Sparkline(
-                            points = extractPoints(moduleKey, history),
-                            modifier = Modifier.fillMaxSize(),
-                            color = MaterialTheme.colorScheme.primary,
-                            fillGradient = true,
-                            animate = true
+                                points = extractPoints(moduleKey, history),
+                                modifier = Modifier.fillMaxSize(),
+                                color = MaterialTheme.colorScheme.primary,
+                                fillGradient = true,
+                                animate = true
                         )
                     }
                 }
             }
         }
 
+        if (moduleKey == "battery") {
+            AppUsageBatterySection(appUsageData = appUsageData, batteryHistory = history)
+        }
+
         if (data.isNotEmpty()) {
             Surface(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(28.dp),
-                color = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp)
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(28.dp),
+                    color = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp)
             ) {
                 Column(
-                    modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                        modifier = Modifier.padding(20.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     Text(
-                        text = stringResource(id = R.string.real_time_metrics),
-                        style = MaterialTheme.typography.titleMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                        fontWeight = FontWeight.Bold
+                            text = stringResource(id = R.string.real_time_metrics),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.Bold
                     )
-                    
+
                     val items = data.toList()
                     items.chunked(2).forEach { rowItems ->
                         Row(modifier = Modifier.fillMaxWidth()) {
                             rowItems.forEach { pair ->
-                                val label = pair.first.substringAfterLast('.').replace("_", " ").replaceFirstChar { it.uppercase() }
-                                StatItem(label = label, value = pair.second, modifier = Modifier.weight(1f))
+                                val label =
+                                        pair.first
+                                                .substringAfterLast('.')
+                                                .replace("_", " ")
+                                                .replaceFirstChar { it.uppercase() }
+                                StatItem(
+                                        label = label,
+                                        value = pair.second,
+                                        modifier = Modifier.weight(1f)
+                                )
                             }
                             if (rowItems.size == 1) Spacer(Modifier.weight(1f))
                         }
@@ -116,40 +135,49 @@ fun ModuleDetailScreen(
 
         if (module != null && sysAccess != null && (hasSettings || isFap)) {
             Surface(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(28.dp),
-                color = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp)
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(28.dp),
+                    color = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp)
             ) {
-                Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Column(
+                        modifier = Modifier.padding(20.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(Icons.Default.Settings, null, modifier = Modifier.size(20.dp), tint = MaterialTheme.colorScheme.primary)
+                        Icon(
+                                Icons.Default.Settings,
+                                null,
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.primary
+                        )
                         Spacer(Modifier.width(8.dp))
                         Text(
-                            text = stringResource(id = R.string.extension_settings),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.primary
+                                text = stringResource(id = R.string.extension_settings),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.primary
                         )
                     }
-                    
+
                     if (hasSettings) {
                         module.settingsContent(context, sysAccess)
                     }
 
                     ModuleNotificationDataPointSettings(
-                        moduleKey = moduleKey,
-                        dataKeys = (data.keys + module.dataPoints().keys).toList()
+                            moduleKey = moduleKey,
+                            dataKeys = (data.keys + module.dataPoints().keys).toList()
                     )
-                    
+
                     if (isFap) {
                         Button(
-                            onClick = {
-                                val intent = Intent(context, MonitorService::class.java)
-                                    .setAction("com.extensionbox.app.FAP_INCREMENT")
-                                context.startService(intent)
-                            },
-                            modifier = Modifier.fillMaxWidth(),
-                            shape = MaterialTheme.shapes.medium
+                                onClick = {
+                                    val intent =
+                                            Intent(context, MonitorService::class.java)
+                                                    .setAction("com.extensionbox.app.FAP_INCREMENT")
+                                    context.startService(intent)
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = MaterialTheme.shapes.medium
                         ) {
                             Icon(Icons.Default.Add, contentDescription = null)
                             Spacer(Modifier.width(8.dp))
@@ -159,56 +187,174 @@ fun ModuleDetailScreen(
                 }
             }
         }
-        
+
         Spacer(modifier = Modifier.height(100.dp))
     }
 }
 
 @Composable
-private fun ModuleNotificationDataPointSettings(
-    moduleKey: String,
-    dataKeys: List<String>
+private fun AppUsageBatterySection(
+        appUsageData: Map<String, String>,
+        batteryHistory: List<ModuleDataEntity>
 ) {
-    val context = LocalContext.current
-    val normalizedKeys = remember(dataKeys) {
-        dataKeys
-            .map { it.substringAfterLast('.') }
-            .distinct()
-            .sorted()
+    val appRows =
+            remember(appUsageData) {
+                appUsageData
+                        .filterKeys { it.startsWith("usage.") }
+                        .mapNotNull { (key, value) ->
+                            val appName = key.removePrefix("usage.").trim()
+                            val durationMs = parseDurationToMillis(value)
+                            if (appName.isNotEmpty() && durationMs > 0) {
+                                AppUsageRow(
+                                        appName = appName,
+                                        durationText = value,
+                                        durationMs = durationMs
+                                )
+                            } else {
+                                null
+                            }
+                        }
+                        .sortedByDescending { it.durationMs }
+                        .take(8)
+            }
+
+    if (appRows.isEmpty()) return
+
+    val batteryDrop = remember(batteryHistory) { estimateBatteryDropPercent(batteryHistory) }
+    val totalUsageMs = appRows.sumOf { it.durationMs }
+
+    Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(28.dp),
+            color = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)
+    ) {
+        Column(
+                modifier = Modifier.padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                    text = "App Usage & Battery Impact",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+            )
+
+            val dropText =
+                    if (batteryDrop > 0f) String.format("%.1f%%", batteryDrop) else "No drop yet"
+            Text(
+                    text = "Estimated from battery drop in this history window: $dropText",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            appRows.forEach { row ->
+                val usageRatio =
+                        if (totalUsageMs > 0L) row.durationMs.toFloat() / totalUsageMs.toFloat()
+                        else 0f
+                val estimatedBattery = batteryDrop * usageRatio
+                Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                                text = row.appName,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                                text = "Usage: ${row.durationText}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Text(
+                            text =
+                                    if (batteryDrop > 0f) String.format("~%.1f%%", estimatedBattery)
+                                    else "—",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
     }
+}
+
+private data class AppUsageRow(val appName: String, val durationText: String, val durationMs: Long)
+
+private fun parseDurationToMillis(value: String): Long {
+    val pattern = Regex("(\\d+)\\s*([dhms])")
+    val matches = pattern.findAll(value.lowercase())
+    var totalMs = 0L
+    matches.forEach { match ->
+        val amount = match.groupValues[1].toLongOrNull() ?: 0L
+        when (match.groupValues[2]) {
+            "d" -> totalMs += amount * 24L * 60L * 60L * 1000L
+            "h" -> totalMs += amount * 60L * 60L * 1000L
+            "m" -> totalMs += amount * 60L * 1000L
+            "s" -> totalMs += amount * 1000L
+        }
+    }
+    return totalMs
+}
+
+private fun estimateBatteryDropPercent(history: List<ModuleDataEntity>): Float {
+    if (history.size < 2) return 0f
+    val first = history.first().data["battery.level"]?.removeSuffix("%")?.trim()?.toFloatOrNull()
+    val last = history.last().data["battery.level"]?.removeSuffix("%")?.trim()?.toFloatOrNull()
+    if (first == null || last == null) return 0f
+    return max(0f, first - last)
+}
+
+@Composable
+private fun ModuleNotificationDataPointSettings(moduleKey: String, dataKeys: List<String>) {
+    val context = LocalContext.current
+    val normalizedKeys =
+            remember(dataKeys) { dataKeys.map { it.substringAfterLast('.') }.distinct().sorted() }
 
     if (normalizedKeys.isEmpty()) return
 
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         Text(
-            text = "Notification Fields",
-            style = MaterialTheme.typography.titleSmall,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface
+                text = "Notification Fields",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface
         )
 
         normalizedKeys.forEach { rawKey ->
-            var isVisible by remember(moduleKey, rawKey) {
-                mutableStateOf(Prefs.isModuleDataPointVisibleInNotif(context, moduleKey, rawKey))
-            }
+            var isVisible by
+                    remember(moduleKey, rawKey) {
+                        mutableStateOf(
+                                Prefs.isModuleDataPointVisibleInNotif(context, moduleKey, rawKey)
+                        )
+                    }
 
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = rawKey.replace("_", " ").replaceFirstChar { it.uppercase() },
-                    modifier = Modifier.weight(1f),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface
+                        text = rawKey.replace("_", " ").replaceFirstChar { it.uppercase() },
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface
                 )
 
                 Switch(
-                    checked = isVisible,
-                    onCheckedChange = { enabled ->
-                        isVisible = enabled
-                        Prefs.setModuleDataPointVisibleInNotif(context, moduleKey, rawKey, enabled)
-                    }
+                        checked = isVisible,
+                        onCheckedChange = { enabled ->
+                            isVisible = enabled
+                            Prefs.setModuleDataPointVisibleInNotif(
+                                    context,
+                                    moduleKey,
+                                    rawKey,
+                                    enabled
+                            )
+                        }
                 )
             }
         }


### PR DESCRIPTION
This PR combines three related UX improvements for module observability and responsiveness.

Adds per-data-point notification visibility controls inside each module’s settings panel.
Improves expanded notification formatting with adaptive line arrangement for better readability.
Adds an “App Usage & Battery Impact” section under the Battery detail history graph, showing app-wise usage time and estimated battery share.
Removes Fap counter update delay by publishing snapshots immediately after increment and refreshing UI/notification/widget in real time.
Overall, users now get more customizable notifications, clearer battery insights, and instant feedback on counter actions.